### PR TITLE
Split deploy step into SCP upload and remote deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,17 +28,27 @@ jobs:
       - name: Build project
         run: npm run build
 
-      # 5. Deploy dist contents to EC2
-      - name: Deploy to EC2
+      # 5. Copy dist/ to EC2
+      - name: Upload dist to EC2
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_KEY }}
+          source: "dist/*"
+          target: "/tmp/myapp"
+
+      # 6. Deploy on EC2
+      - name: Deploy to Nginx directory
         uses: appleboy/ssh-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_KEY }}
-          port: 22
           script: |
+            sudo mkdir -p /usr/share/nginx/html/myapp
             sudo rm -rf /usr/share/nginx/html/myapp/*
-            sudo cp -r dist/* /usr/share/nginx/html/myapp/
+            sudo cp -r /tmp/myapp/* /usr/share/nginx/html/myapp/
             sudo chown -R nginx:nginx /usr/share/nginx/html/myapp
             sudo chmod -R 755 /usr/share/nginx/html/myapp
             sudo systemctl restart nginx


### PR DESCRIPTION
The deployment process now uploads the build artifacts to the EC2 instance using appleboy/scp-action, then copies them to the Nginx directory via a separate SSH step. This improves clarity and separation of concerns in the deployment workflow.